### PR TITLE
Sad path show

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,13 @@
 class ApplicationController < ActionController::Base
+rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+  def render_404
+    render file: "#{Rails.root}/public/404.html", status: 404
+  end
 
   private
   def error_message(errors)
     errors.full_messages.join(", ")
   end
+
 end

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,8 +1,5 @@
 class CreditCardsController < ApplicationController 
   def show 
     @credit_card = CreditCard.find(params[:id])
-
-    #   flash[:error] = @credit_card.errors.full_messages.to_sentence
-  
   end
 end

--- a/spec/features/credit_card/show_spec.rb
+++ b/spec/features/credit_card/show_spec.rb
@@ -34,11 +34,10 @@ RSpec.describe "Credit Card Show Page" do
   end
 
   describe "sad_path" do 
-    # it "will not go to a random page for a card that doesnt exist" do 
-    #   visit "/credit_cards/#{5555}"
-    #   # save_and_open_page
-
-    #   expect(request).to raise_error(ActiveRecord::RecordNotFound)
-    # end
+    it "will not go to a random page for a card that doesnt exist" do 
+      visit "/credit_cards/#{5555}"
+   
+      expect(page).to have_content("404")
+    end
   end
 end


### PR DESCRIPTION
Add rescue from record not found in application controller. Test that page renders 404 error if an id not in the database is entered.